### PR TITLE
Add experimental support for non-x86 archs and MacOS

### DIFF
--- a/include/native/wsi/native_sdl2.h
+++ b/include/native/wsi/native_sdl2.h
@@ -1,7 +1,8 @@
 #include <cstdint>
 #include <windows.h>
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
+#include <SDL_vulkan.h>
 
 namespace dxvk::wsi {
 

--- a/meson.build
+++ b/meson.build
@@ -147,10 +147,12 @@ else
     wrc = find_program('rc')
   else
     dxvk_include_path = include_directories('./include', './include/native/', './include/native/windows', './include/native/directx')
-    lib_vulkan  = dxvk_compiler.find_library('vulkan')
-    lib_sdl2    = dxvk_compiler.find_library('SDL2')
+    lib_sdl2    = dependency('SDL2')
+    lib_vulkan  = dependency('vulkan')
     wrc = find_program('echo')
     so_prefix = 'libdxvk_'
+    #Required to allow dxvk_sdl2_exts.cpp find SDL.h
+    dxvk_extradep += [ lib_sdl2 ]
   endif
 
   res_ext = ''

--- a/meson.build
+++ b/meson.build
@@ -52,10 +52,17 @@ endif
 
 dxvk_include_path = include_directories('./include')
 
-if (cpu_family == 'x86_64')
+if (cpu_family == 'x86_64' or cpu_family == 'aarch64')
   dxvk_library_path = meson.source_root() + '/lib'
 else
   dxvk_library_path = meson.source_root() + '/lib32'
+endif
+
+# Set define for arch type (x86/x86_64 or ARM/AArch64)
+if (cpu_family == 'x86' or cpu_family == 'x86_64')
+  add_project_arguments('-DCPU_ARCH_X86', language : ['c', 'cpp'])
+elif (cpu_family == 'arm' or cpu_family == 'aarch64')
+  add_project_arguments('-DCPU_ARCH_ARM', language : ['c', 'cpp'])
 endif
 
 dxvk_extradep = [ ]

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3836,7 +3836,7 @@ namespace dxvk {
     DxvkDeviceFeatures enabled = {};
 
     // Geometry shaders are used for some meta ops
-    enabled.core.features.geometryShader = VK_TRUE;
+    enabled.core.features.geometryShader = supported.core.features.geometryShader;
     enabled.core.features.robustBufferAccess = VK_TRUE;
     enabled.extRobustness2.robustBufferAccess2 = supported.extRobustness2.robustBufferAccess2;
 
@@ -3865,7 +3865,7 @@ namespace dxvk {
     enabled.core.features.sampleRateShading = VK_TRUE;
     enabled.core.features.samplerAnisotropy = supported.core.features.samplerAnisotropy;
     enabled.core.features.shaderClipDistance = VK_TRUE;
-    enabled.core.features.shaderCullDistance = VK_TRUE;
+    enabled.core.features.shaderCullDistance = supported.core.features.shaderCullDistance;
 
     // Ensure we support real BC formats and unofficial vendor ones.
     enabled.core.features.textureCompressionBC = VK_TRUE;

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -252,8 +252,10 @@ namespace dxvk {
           std::memcpy(set.fConsts[StartRegister].data, pConstantData, size);
         }
         else {
-          for (UINT i = 0; i < Count; i++)
-            set.fConsts[StartRegister + i] = replaceNaN(pConstantData + (i * 4));
+          for (UINT i = 0; i < Count; i++) {
+              const T* a = pConstantData + (i * 4);
+              set.fConsts[StartRegister + i] = replaceNaN(Vector4(a[0], a[1], a[2], a[3]));
+          }
         }
       }
       else if constexpr (ConstantType == D3D9ConstantType::Int) {

--- a/src/dxvk/platform/dxvk_sdl2_exts.cpp
+++ b/src/dxvk/platform/dxvk_sdl2_exts.cpp
@@ -1,7 +1,7 @@
 #include "../dxvk_platform_exts.h"
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_vulkan.h>
+#include <SDL.h>
+#include <SDL_vulkan.h>
 
 namespace dxvk {
 

--- a/src/util/meson.build
+++ b/src/util/meson.build
@@ -33,10 +33,19 @@ util_src_linux = [
   'platform/thread_native.cpp',
 ]
 
+util_src_darwin = [
+  'platform/util_luid_linux.cpp',
+  'platform/util_env_darwin.cpp',
+  'platform/util_string_linux.cpp',
+  'platform/thread_native.cpp',
+]
+
 if dxvk_platform == 'windows'
   util_src += util_src_win32
 elif dxvk_platform == 'linux'
   util_src += util_src_linux
+elif dxvk_platform == 'darwin'
+  util_src += util_src_darwin
 else
   error('Unknown platform for util')
 endif

--- a/src/util/platform/util_env_darwin.cpp
+++ b/src/util/platform/util_env_darwin.cpp
@@ -1,0 +1,32 @@
+#include "util_env.h"
+
+#include <array>
+#include <filesystem>
+#include <limits.h>
+
+//Namespace to avoid mixing definitions such as TRUE/FALSE
+namespace dyld {
+#include <mach-o/dyld.h>
+}
+
+namespace dxvk::env {
+
+  std::string getExePath() {
+    std::array<char, PATH_MAX> exePath = {};
+    uint32_t size = PATH_MAX;
+
+    bool success = dyld::_NSGetExecutablePath(exePath.data(), &size) == 0;
+
+    return std::string(success ? exePath.data() : "");
+  }
+  
+  
+  void setThreadName(const std::string& name) {
+  }
+
+
+  bool createDirectory(const std::string& path) {
+    return std::filesystem::create_directories(path);
+  }
+
+}

--- a/src/util/sync/sync_spinlock.h
+++ b/src/util/sync/sync_spinlock.h
@@ -21,7 +21,11 @@ namespace dxvk::sync {
   void spin(uint32_t spinCount, const Fn& fn) {
     while (unlikely(!fn())) {
       for (uint32_t i = 1; i < spinCount; i++) {
+#if defined(CPU_ARCH_X86)
         _mm_pause();
+#elif defined(CPU_ARCH_ARM)
+        __asm__ __volatile__ ("yield");
+#endif
         if (fn())
           return;
       }

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#if defined(CPU_ARCH_X86)
 #ifndef _MSC_VER
 #if defined(__WINE__) && defined(__clang__)
 #pragma push_macro("_WIN32")
@@ -11,6 +12,7 @@
 #endif
 #else
 #include <intrin.h>
+#endif
 #endif
 
 #include "util_likely.h"
@@ -55,7 +57,7 @@ namespace dxvk::bit {
     return _tzcnt_u32(n);
     #elif defined(__BMI__)
     return __tzcnt_u32(n);
-    #elif defined(__GNUC__) || defined(__clang__)
+    #elif defined(CPU_ARCH_X86) && (defined(__GNUC__) || defined(__clang__))
     uint32_t res;
     uint32_t tmp;
     asm (
@@ -144,7 +146,7 @@ namespace dxvk::bit {
   template<typename T>
   bool bcmpeq(const T* a, const T* b) {
     static_assert(alignof(T) >= 16);
-    #if defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER)
+    #if defined(CPU_ARCH_X86) && (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))
     auto ai = reinterpret_cast<const __m128i*>(a);
     auto bi = reinterpret_cast<const __m128i*>(b);
 

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -55,7 +55,7 @@ namespace dxvk::bit {
   inline uint32_t tzcnt(uint32_t n) {
     #if defined(_MSC_VER) && !defined(__clang__)
     return _tzcnt_u32(n);
-    #elif defined(__BMI__)
+    #elif defined(CPU_ARCH_X86) && defined(__BMI__)
     return __tzcnt_u32(n);
     #elif defined(CPU_ARCH_X86) && (defined(__GNUC__) || defined(__clang__))
     uint32_t res;
@@ -99,7 +99,7 @@ namespace dxvk::bit {
   }
 
   inline uint32_t lzcnt(uint32_t n) {
-    #if (defined(_MSC_VER) && !defined(__clang__)) || defined(__LZCNT__)
+    #if (defined(_MSC_VER) && !defined(__clang__)) || (defined(CPU_ARCH_X86) && defined(__LZCNT__))
     return _lzcnt_u32(n);
     #elif defined(__GNUC__) || defined(__clang__)
     return n != 0 ? __builtin_clz(n) : 32;

--- a/src/util/util_vector.h
+++ b/src/util/util_vector.h
@@ -151,10 +151,16 @@ namespace dxvk {
 
   inline Vector4 replaceNaN(Vector4 a) {
     Vector4 result;
+#ifdef CPU_ARCH_X86
     __m128 value = _mm_load_ps(a.data);
     __m128 mask  = _mm_cmpeq_ps(value, value);
            value = _mm_and_ps(value, mask);
     _mm_store_ps(result.data, value);
+#else
+      for (int i = 0; i < 4; ++i) {
+          if (a[i] != a[i]) a[i] = 0.0f;
+      }    
+#endif
     return result;
   }
 

--- a/src/wsi/sdl2/wsi_helpers_sdl2.h
+++ b/src/wsi/sdl2/wsi_helpers_sdl2.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_vulkan.h>
+#include <SDL.h>
+#include <SDL_vulkan.h>
 
 #include "../wsi_monitor.h"
 

--- a/src/wsi/sdl2/wsi_presenter_sdl2.cpp
+++ b/src/wsi/sdl2/wsi_presenter_sdl2.cpp
@@ -1,7 +1,7 @@
 #include "../wsi_presenter.h"
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_vulkan.h>
+#include <SDL.h>
+#include <SDL_vulkan.h>
 
 #include <wsi/native_wsi.h>
 

--- a/tests/native/test_native_d3d11.cpp
+++ b/tests/native/test_native_d3d11.cpp
@@ -1,5 +1,5 @@
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_vulkan.h>
+#include <SDL.h>
+#include <SDL_vulkan.h>
 
 #include <cstring>
 #include <string>

--- a/tests/native/test_native_d3d9.cpp
+++ b/tests/native/test_native_d3d9.cpp
@@ -1,5 +1,5 @@
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_vulkan.h>
+#include <SDL.h>
+#include <SDL_vulkan.h>
 
 #include <cstring>
 


### PR DESCRIPTION
This PR makes x86 specifics optional in case the platform is different to allow compiling it under ARM64 (not tested in other archs)

Also adds changes required to make it compile under MacOS and run a D3D9 using game.

Please review my changes carefully as this is not my area of expertise and there may be better ways to do this.
