### PR TITLE
Allow cross-compiling for i386 Linux on x86_64 Linux

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@ else
   dxvk_cpp_std='c++17'
 endif
 
-dxvk_native = (not meson.is_cross_build() and not dxvk_is_msvc) or get_option('dxvk_native_force')
+dxvk_native = (host_machine.system() != 'windows' and not dxvk_is_msvc) or get_option('dxvk_native_force')
 
 if dxvk_is_msvc
   add_project_arguments('/std:' + dxvk_cpp_std, language : 'cpp')

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('dxvk', ['c', 'cpp'], version : 'v1.9.2', meson_version : '>= 0.46')
 
-cpu_family = target_machine.cpu_family()
+cpu_family = host_machine.cpu_family()
 
 add_project_arguments('-DNOMINMAX', language : 'cpp')
 
@@ -43,7 +43,7 @@ if not dxvk_is_msvc
   endif
 
   # Wine's built-in back traces only work with dwarf2 symbols
-  if get_option('debug') and target_machine.system() == 'windows'
+  if get_option('debug') and host_machine.system() == 'windows'
     if dxvk_compiler.has_argument('-gstrict-dwarf') and dxvk_compiler.has_argument('-gdwarf-2')
       add_project_arguments('-gstrict-dwarf', '-gdwarf-2', language: ['c', 'cpp'])
     endif
@@ -121,7 +121,7 @@ else
   add_project_arguments('-DDXVK_NATIVE', language : 'cpp')
 
   dxvk_wsi      = get_option('dxvk_native_wsi')
-  dxvk_platform = target_machine.system()
+  dxvk_platform = host_machine.system()
 
   if cpu_family == 'x86'
     if dxvk_compiler.has_argument('-msse') and dxvk_compiler.has_argument('-msse2')

--- a/package-native.sh
+++ b/package-native.sh
@@ -5,7 +5,7 @@ set -e
 shopt -s extglob
 
 if [ -z "$1" ] || [ -z "$2" ]; then
-  echo "Usage: $0 version destdir [--no-package] [--dev-build]"
+  echo "Usage: $0 version destdir [--no-package] [--dev-build] [-- MESON_OPTIONS]"
   exit 1
 fi
 
@@ -37,6 +37,10 @@ while [ $# -gt 0 ]; do
   "--build-id")
     opt_buildid=true
     ;;
+  "--")
+    shift
+    break
+    ;;
   *)
     echo "Unrecognized option: $1" >&2
     exit 1
@@ -57,6 +61,7 @@ function build_arch {
         $opt_strip                                    \
         -Denable_tests=true                           \
         -Dbuild_id=$opt_buildid                       \
+        "$@"                                          \
         "$DXVK_BUILD_DIR/build"
 
   cd "$DXVK_BUILD_DIR/build"
@@ -74,7 +79,7 @@ function package {
   rm -R "dxvk-native-$DXVK_VERSION"
 }
 
-build_arch
+build_arch "$@"
 
 if [ $opt_nopackage -eq 0 ]; then
   package


### PR DESCRIPTION
* [build] Consistently use host_machine rather than target_machine
    
    Meson uses the same terminology as Autotools, where you build on the
    build system, producing binaries for the host system, and the target
    system is only relevant when compiling compilers. This isn't a compiler,
    so it's confusing to use target_machine (although mostly harmless since
    target_machine defaults to being the same as host_machine).

* [build] Allow cross-compiling for i386 Linux on x86_64 Linux
    
    We only need windres if we're producing Windows binaries. In the
    dxvk-native use-case, cross-compiling for i386 on x86_64 (or in
    principle cross-compiling for x86 on non-x86) still counts as "native"
    in the sense that we're producing Linux binaries.

* [build] Allow passing arbitrary Meson options to package-native.sh
    
    This can be used with a --cross-file to cross-compile an i386 version
    of dxvk-native on x86_64. In particular, native Linux games that run on
    Steam Runtime 3 'sniper' will want this if they're still compiled for
    i386, because the sniper SDK is only available as an x86_64 container
    with secondary i386 support.